### PR TITLE
Upgrade pcb-stackup-core to v2

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -5,7 +5,7 @@ browsers:
   - name: safari
     version: -1..latest
   - name: firefox
-    version: [-1..46]
+    version: -1..latest
   - name: ie
     version: -1..latest
   - name: microsoftedge

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # pcb stackup
 
-[![GitHub stars](https://img.shields.io/github/stars/tracespace/pcb-stackup.svg?style=flat-square&label=%E2%AD%90&maxAge=2592000)](https://github.com/tracespace/pcb-stackup)
-[![GitHub issues](https://img.shields.io/github/issues/tracespace/pcb-stackup.svg?style=flat-square&maxAge=2592000)](https://github.com/tracespace/pcb-stackup/issues)
-[![npm](https://img.shields.io/npm/v/pcb-stackup.svg?style=flat-square)](https://www.npmjs.com/package/pcb-stackup)
-[![Travis](https://img.shields.io/travis/tracespace/pcb-stackup/master.svg?style=flat-square)](https://travis-ci.org/tracespace/pcb-stackup)
-[![Coveralls](https://img.shields.io/coveralls/tracespace/pcb-stackup.svg?style=flat-square)](https://coveralls.io/github/tracespace/pcb-stackup)
-[![David](https://img.shields.io/david/tracespace/pcb-stackup.svg?style=flat-square)](https://david-dm.org/tracespace/pcb-stackup)
-[![David](https://img.shields.io/david/dev/tracespace/pcb-stackup.svg?style=flat-square)](https://david-dm.org/tracespace/pcb-stackup#info=devDependencies)
+[![GitHub stars](https://img.shields.io/github/stars/tracespace/pcb-stackup.svg?style=flat-square&label=%E2%AD%90&maxAge=86400)](https://github.com/tracespace/pcb-stackup)
+[![GitHub issues](https://img.shields.io/github/issues/tracespace/pcb-stackup.svg?style=flat-square&maxAge=86400)](https://github.com/tracespace/pcb-stackup/issues)
+[![npm](https://img.shields.io/npm/v/pcb-stackup.svg?style=flat-square&maxAge=86400)](https://www.npmjs.com/package/pcb-stackup)
+[![Travis](https://img.shields.io/travis/tracespace/pcb-stackup/master.svg?style=flat-square&maxAge=86400)](https://travis-ci.org/tracespace/pcb-stackup)
+[![codecov](https://img.shields.io/codecov/c/github/tracespace/pcb-stackup.svg?style=flat-square&maxAge=86400)](https://codecov.io/gh/tracespace/pcb-stackup)
+[![David](https://img.shields.io/david/tracespace/pcb-stackup.svg?style=flat-square&maxAge=86400)](https://david-dm.org/tracespace/pcb-stackup)
+[![David](https://img.shields.io/david/dev/tracespace/pcb-stackup.svg?style=flat-square&maxAge=86400)](https://david-dm.org/tracespace/pcb-stackup#info=devDependencies)
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/pcb-stackup.svg)](https://saucelabs.com/u/pcb-stackup)
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:sauce": "zuul -- ./test.js",
     "coverage": "nyc report",
     "coverage:html": "nyc report --reporter=html",
-    "coverage:ci": "nyc report --reporter=text-lcov | coveralls",
+    "coverage:ci": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "ci": "npm test && if [ \"${TEST_BROWSERS}\" = \"true\" ]; then npm run ci:browser; fi",
     "ci:browser": "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then npm run test:sauce; fi",
     "postci": "npm run coverage:ci",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "chai": "^3.5.0",
-    "coveralls": "^2.11.9",
+    "codecov": "^1.0.1",
     "domify": "^1.4.0",
     "eslint": "^2.9.0",
     "glob": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "gerber-to-svg": "^2.1.0",
-    "pcb-stackup-core": "^1.0.0",
+    "pcb-stackup-core": "^2.0.1",
     "shortid": "^2.2.6",
     "whats-that-gerber": "^2.0.1"
   }


### PR DESCRIPTION
This PR updates pcb-stackup-core to latest (v2.0.1). It also switches from coveralls to codecov for coverage because coveralls has been causing CI builds to fail.

Should probably be considered a major because the pcb-stackup-core bump is major.