### PR TITLE
Make layers cache actually work

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -12,6 +12,7 @@ browsers:
     version: latest
 browserify:
   - plugin: proxyquire-universal
+  - transform: brfs
 concurrency: 4
 tunnel:
   type: ngrok

--- a/index.js
+++ b/index.js
@@ -74,13 +74,9 @@ var pcbStackup = function(layers, options, done) {
       var stackup = createStackup(stackupLayers, options)
 
       stackup.layers = stackupLayers.map(function(layer) {
-        var converter = layer.converter
-
-        converter.options = layer.options
-
         return {
           layerType: layer.type,
-          converter: converter,
+          converter: layer.converter,
           options: layer.options
         }
       })
@@ -104,7 +100,15 @@ var pcbStackup = function(layers, options, done) {
       layerOptions.plotAsOutline = options.outlineGapFill
     }
 
-    var converter = layer.converter || gerberToSvg(layer.gerber, layerOptions, finishLayer)
+    var usePreConverted = layer.gerber == null
+    var converter
+
+    if (usePreConverted) {
+      converter = layer.converter
+    }
+    else {
+      converter = gerberToSvg(layer.gerber, layerOptions, finishLayer)
+    }
 
     stackupLayers.push({
       type: layerType,
@@ -112,7 +116,7 @@ var pcbStackup = function(layers, options, done) {
       options: layerOptions
     })
 
-    if (layer.converter) {
+    if (usePreConverted) {
       finishLayer()
     }
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var getInvalidLayers = function(layers) {
   }, {argErrors: [], layerTypeErrors: []} )
 }
 
+
 var pcbStackup = function(layers, options, done) {
   if (typeof options === 'function') {
     done = options
@@ -73,9 +74,13 @@ var pcbStackup = function(layers, options, done) {
       var stackup = createStackup(stackupLayers, options)
 
       stackup.layers = stackupLayers.map(function(layer) {
+        var converter = layer.converter
+
+        converter.options = layer.options
+
         return {
           layerType: layer.type,
-          gerber: layer.converter,
+          converter: converter,
           options: layer.options
         }
       })
@@ -99,13 +104,18 @@ var pcbStackup = function(layers, options, done) {
       layerOptions.plotAsOutline = options.outlineGapFill
     }
 
-    var converter = gerberToSvg(layer.gerber, layerOptions, finishLayer)
+    var converter = layer.converter || gerberToSvg(layer.gerber, layerOptions, finishLayer)
 
     stackupLayers.push({
       type: layerType,
       converter: converter,
       options: layerOptions
     })
+
+    if (layer.converter) {
+      finishLayer()
+    }
+
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/tracespace/pcb-stackup",
   "devDependencies": {
+    "brfs": "^1.4.3",
     "browserify": "^13.0.0",
     "chai": "^3.5.0",
     "codecov": "^1.0.1",

--- a/test.js
+++ b/test.js
@@ -106,7 +106,7 @@ describe('easy stackup function', function() {
       expect(stackup).to.be.an('object')
       expect(stackup).to.have.all.keys('top', 'bottom', 'layers')
       expect(stackup.layers).to.be.an.instanceOf(Array)
-      expect(stackup.layers[0]).to.have.all.keys('layerType', 'gerber', 'options')
+      expect(stackup.layers[0]).to.have.all.keys('layerType', 'converter', 'options')
       done()
     })
   })
@@ -164,8 +164,8 @@ describe('easy stackup function', function() {
 
     pcbStackup(layers, options, function(error, stackup) {
       expect(error).to.not.exist
-      expect(stackup.layers[0].gerber['_element']()).to.equal(1)
-      expect(stackup.layers[1].gerber['_element']()).to.equal(1)
+      expect(stackup.layers[0].converter['_element']()).to.equal(1)
+      expect(stackup.layers[1].converter['_element']()).to.equal(1)
       done()
     })
   })
@@ -179,8 +179,8 @@ describe('easy stackup function', function() {
 
     pcbStackup(layers, options, function(error, stackup) {
       expect(error).to.not.exist
-      expect(stackup.layers[0].gerber['_element']()).to.equal(1)
-      expect(stackup.layers[1].gerber['_element']()).to.equal(1)
+      expect(stackup.layers[0].converter['_element']()).to.equal(1)
+      expect(stackup.layers[1].converter['_element']()).to.equal(1)
       done()
     })
   })

--- a/test.js
+++ b/test.js
@@ -211,10 +211,11 @@ describe('easy stackup function', function() {
   // style framework instead of single unit tests
   // NOTE: (mc) Perhaps instead of these tests, we should check that we're passing
   // the correct things to gerber-to-svg, whats-that-gerber, and pcb-stackup-core?
-  it('has deterministic top and bottom svgs if ids are given', function(done) {
-    var exampleGerber1 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.plc'))
-    var exampleGerber2 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.gko'))
 
+  var exampleGerber1 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.plc'))
+  var exampleGerber2 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.gko'))
+
+  it('has deterministic top and bottom svgs if ids are given', function(done) {
     var layers = [
       {gerber: exampleGerber1, layerType: 'bcu', options: {id: 'a'}},
       {gerber: exampleGerber2, layerType: 'tcu', options: {id: 'b'}}
@@ -234,8 +235,6 @@ describe('easy stackup function', function() {
   })
 
   it('has deterministic top and bottom svgs if ids are given and passed back its own output', function(done) {
-    var exampleGerber1 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.plc'))
-    var exampleGerber2 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.gko'))
     var layers = [
       {gerber: exampleGerber1, layerType: 'bcu', options: {id: 'a'}},
       {gerber: exampleGerber2, layerType: 'tcu', options: {id: 'b'}}
@@ -255,8 +254,6 @@ describe('easy stackup function', function() {
   })
 
   it('lets you replace gerber in layer cache', function(done) {
-    var exampleGerber1 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.plc'))
-    var exampleGerber2 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.gko'))
     var layers = [
       {gerber: exampleGerber1, layerType: 'bcu', options: {id: 'a'}},
       {gerber: exampleGerber2, layerType: 'tcu', options: {id: 'b'}}

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 // test suite for simpler API
 'use strict'
+var fs = require('fs')
+var path = require('path')
 
 var expect = require('chai').expect
 
@@ -209,9 +211,12 @@ describe('easy stackup function', function() {
   // NOTE: (mc) Perhaps instead of these tests, we should check that we're passing
   // the correct things to gerber-to-svg, whats-that-gerber, and pcb-stackup-core?
   it('has deterministic top and bottom svgs if ids are given', function(done) {
+    var exampleGerber1 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.plc'))
+    var exampleGerber2 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.gko'))
+
     var layers = [
-      {gerber: emptyGerber, layerType: 'bcu', options: {id: 'a'}},
-      {gerber: emptyGerber, layerType: 'tcu', options: {id: 'b'}}
+      {gerber: exampleGerber1, layerType: 'bcu', options: {id: 'a'}},
+      {gerber: exampleGerber2, layerType: 'tcu', options: {id: 'b'}}
     ]
 
     pcbStackup(layers, {id: 'c'}, function(error, stackup1) {
@@ -221,16 +226,18 @@ describe('easy stackup function', function() {
       pcbStackup(layers, {id: 'c'}, function(error, stackup2) {
         expect(error).to.not.exist
         expect(stackup2.top).to.deep.equal(stackup1.top)
-        expect(stackup2.bottom).to.deep.equal(stackup2.bottom)
+        expect(stackup2.bottom).to.deep.equal(stackup1.bottom)
         done()
       })
     })
   })
 
   it('has deterministic top and bottom svgs if ids are given and passed back its own output', function(done) {
+    var exampleGerber1 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.plc'))
+    var exampleGerber2 = fs.readFileSync(path.join(__dirname, 'integration/boards/arduino-uno/arduino-uno.gko'))
     var layers = [
-      {gerber: emptyGerber, layerType: 'bcu', options: {id: 'a'}},
-      {gerber: emptyGerber, layerType: 'tcu', options: {id: 'b'}}
+      {gerber: exampleGerber1, layerType: 'bcu', options: {id: 'a'}},
+      {gerber: exampleGerber2, layerType: 'tcu', options: {id: 'b'}}
     ]
 
     pcbStackup(layers, {id: 'c'}, function(error, stackup1) {
@@ -240,7 +247,7 @@ describe('easy stackup function', function() {
       pcbStackup(stackup1.layers, {id: 'c'}, function(error, stackup2) {
         expect(error).to.not.exist
         expect(stackup2.top).to.deep.equal(stackup1.top)
-        expect(stackup2.bottom).to.deep.equal(stackup2.bottom)
+        expect(stackup2.bottom).to.deep.equal(stackup1.bottom)
         done()
       })
     })


### PR DESCRIPTION
Looks like passing back the "layers" cache isn't working as we intended. I think it's giving back empty (invalid?) SVGs on the second pass. 

I was experiencing this when trying to make use of it in Kitnic and modified the tests to verify. They fail with these modifications.  [Full test output is here](https://gist.github.com/kasbah/0164cce32e262ad3b800cc89c18d5dfe).

As always, any insight appreciated. 